### PR TITLE
Update Bug Reports

### DIFF
--- a/Bug Reports
+++ b/Bug Reports
@@ -1,1 +1,25 @@
 
+# 🐞 Bug Report: Reset password email not sent
+
+## 🧪 Pre-conditions:
+- User is on the "Forgot password" page
+
+## ✅ Steps to reproduce:
+1. Click on "Forgot Password"
+2. Ensure the email field is visible
+3. Enter valid email
+4. Click on "Reset Password" button
+5. Check email inbox
+
+## 🔴 Actual Result:
+- The user receives an empty email message titled "Reset password"
+
+## 🟢 Expected Result:
+- User should see a message in the email body: *"Email sent with reset instructions"*
+
+## 💥 Severity:
+- Blocker
+
+## 🌐 Environment:
+- Browser: Google Chrome  
+- Version: 137.0.7151.56 (64-bit)


### PR DESCRIPTION
# 🐞 Bug Report: Reset password email not sent

## 🧪 Pre-conditions:
- User is on the "Forgot password" page

## ✅ Steps to reproduce:
1. Click on "Forgot Password"
2. Ensure the email field is visible
3. Enter valid email
4. Click on "Reset Password" button
5. Check email inbox

## 🔴 Actual Result:
- The user receives an empty email message titled "Reset password"

## 🟢 Expected Result:
- User should see a message in the email body: *"Email sent with reset instructions"*

## 💥 Severity:
- Blocker

## 🌐 Environment:
- Browser: Google Chrome  
- Version: 137.0.7151.56 (64-bit)